### PR TITLE
derive Copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
 /// A tuple struct representing an unordered pair
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Copy, Clone, Eq)]
 pub struct UnorderedPair<T>(pub T, pub T);
 
 impl<T> From<(T, T)> for UnorderedPair<T> {


### PR DESCRIPTION
Derive the `Copy` trait so that `Unordered<T>` is Copy when T is Copy.