### PR TITLE
Replace Into impl with From impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@ impl<T> From<(T, T)> for UnorderedPair<T> {
     }
 }
 
-impl<T> Into<(T, T)> for UnorderedPair<T> {
-    fn into(self) -> (T, T) {
-        (self.0, self.1)
+impl<T> From<UnorderedPair<T>> for (T, T) {
+    fn from(pair: UnorderedPair<T>) -> (T, T) {
+        (pair.0, pair.1)
     }
 }
 


### PR DESCRIPTION
Clippy suggestion.
Not sure if this is a breaking change. The `Into` impl is still there because of the [blanket impl](https://doc.rust-lang.org/src/core/convert/mod.rs.html#541-552). In addition, we get the `From` impl now.